### PR TITLE
Fix hostname not showing

### DIFF
--- a/conf/awesome/misc/sidebar/profile.lua
+++ b/conf/awesome/misc/sidebar/profile.lua
@@ -35,7 +35,7 @@ local hostname = wibox.widget.textbox()
 hostname.font = "Roboto Regular 14"
 hostname.align = 'left'
 
-awful.spawn.easy_async_with_shell("echo $HOST", function(stdout)
+awful.spawn.easy_async_with_shell("cat /proc/sys/kernel/hostname", function(stdout)
 	hostname.markup = "@"..tostring(stdout)
 end)
 


### PR DESCRIPTION
as written in #15, https://github.com/rklyz/MyRice/issues/15#issuecomment-1257206681

replaces awesome.misc.sidebar.profile, line 38 with
```
awful.spawn.easy_async_with_shell("cat /proc/sys/kernel/hostname", function(stdout)
  hostname.markup = "@"..tostring(stdout)
end)
```
to show real hostname