### PR TITLE
Add systray on statusbar

### DIFF
--- a/conf/awesome/misc/bar/init.lua
+++ b/conf/awesome/misc/bar/init.lua
@@ -35,9 +35,29 @@ local info = wibox.widget {
 	widget = wibox.container.margin,
 }
 
+-- Systray
+local systray = wibox.widget {
+	{
+		{
+			{
+        wibox.widget.systray,
+				layout = wibox.layout.fixed.horizontal,
+			},
+			margins = {top = dpi(2), bottom = dpi(2), left = dpi(6), right = dpi(6)},
+			widget = wibox.container.margin,
+		},
+		shape = function(cr,w,h) gears.shape.rounded_rect(cr,w,h,8) end,
+		bg = beautiful.bg_alt,
+		widget = wibox.container.background,
+	},
+	margins = {top = dpi(6), bottom = dpi(6)},
+	widget = wibox.container.margin,
+}
+
 -- Right
 local right = wibox.widget {
 	{
+    systray,
 		info,
 		clock,
 		launcher,

--- a/conf/awesome/theme/theme.lua
+++ b/conf/awesome/theme/theme.lua
@@ -60,10 +60,10 @@ theme.bg_alt = colors.bg_alt
 ----- General/default Settings -----
 
 theme.bg_normal     = theme.bg
-theme.bg_focus      = "#e8e9ec"
-theme.bg_urgent     = "#e8e9ec"
-theme.bg_minimize   = "#e8e9ec"
-theme.bg_systray    = "#e8e9ec"
+theme.bg_focus      = "#212126"
+theme.bg_urgent     = "#212126"
+theme.bg_minimize   = "#212126"
+theme.bg_systray    = "#212126"
 
 theme.fg_normal     = theme.fg
 theme.fg_focus      = theme.fg_normal


### PR DESCRIPTION
As mentioned in #15, this commit now adds tray icons to the status bar, now able to see apps, and close apps that are running in the background ( aka. minimized to tray ), such as steam, discord, garena, spotify etc

![26-09-2022-01:32:03-screenshot](https://user-images.githubusercontent.com/64385071/192157125-df9da2ce-5009-43c1-8feb-0fc636f3a0e9.jpg)
